### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Sanji Framework SDK (Python)
     :target: https://travis-ci.org/Sanji-IO/sanji
     :alt: Build Status
 
-.. image:: https://pypip.in/version/sanji/badge.svg
+.. image:: https://img.shields.io/pypi/v/sanji.svg
     :target: https://pypi.python.org/pypi/sanji/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sanji))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sanji`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.